### PR TITLE
Add dynamic mood rendering for frontend

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -44,7 +44,7 @@ async def get_tracks(
     response_description='List of moods',
 )
 async def get_tracks() -> list[str]:
-    return get_moods()
+    return sorted(get_moods())
 
 @app.get(
     '/get-recommendations',

--- a/frontend/src/routes/tags.jsx
+++ b/frontend/src/routes/tags.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button, Container, Col, Form, Row } from 'react-bootstrap';
 
 export default function Tags() {
@@ -10,6 +10,14 @@ export default function Tags() {
     artist: '',
     link: '',
     image: '',
+  });
+  const [moods, setMoods] = useState([]);
+
+  useEffect(() => {
+    let request = 'http://localhost:8000/get-moods';
+    fetch(request)
+      .then(res => res.json())
+      .then(data => setMoods(data))
   });
 
   // These boolean states might not be necessary
@@ -71,7 +79,7 @@ export default function Tags() {
           <h3>Select your tags</h3>
           <Col>
             <h3>Mood</h3>
-            {['happy', 'sad', 'horror'].map((tag) => (
+            {moods.map((tag) => (
               <div key={tag} className="mb-3">
                 <Form.Check 
                   name='tag'

--- a/frontend/src/routes/tags.jsx
+++ b/frontend/src/routes/tags.jsx
@@ -18,7 +18,7 @@ export default function Tags() {
     fetch(request)
       .then(res => res.json())
       .then(data => setMoods(data))
-  });
+  }, []);
 
   // These boolean states might not be necessary
   const [tagSelected, setTagSelected] = useState(false);


### PR DESCRIPTION
Now moods are rendered dynamically based on what moods are available in the backend. The backend `/get-moods` endpoint returns all the available moods, and the frontend displays that.

![image](https://user-images.githubusercontent.com/35665983/180801651-0c0e9937-604a-436a-9561-7cfdaf9650e8.png)