### PR TITLE
Added audio controls for playing 30 second preview

### DIFF
--- a/frontend/src/routes/tags.jsx
+++ b/frontend/src/routes/tags.jsx
@@ -10,6 +10,7 @@ export default function Tags() {
     artist: '',
     link: '',
     image: '',
+    mp3: '',
   });
   const [moods, setMoods] = useState([]);
 
@@ -47,6 +48,7 @@ export default function Tags() {
           name: data[0].name,
           link: data[0].external_urls.spotify,
           image: data[0].album.images[0].url,
+          mp3: data[0].preview_url,
         })
       });
   }
@@ -67,7 +69,13 @@ export default function Tags() {
         <br/>
         {songInfo.artist + ' - ' + songInfo.name}
       </a>
-      
+      <br/>
+      <audio controls>
+        <source 
+          src={songInfo.mp3}
+          type="audio/mp3"
+        />
+      </audio>
     </p>
   )
 


### PR DESCRIPTION
1. This adds an audio control for the 30 second preview, NOT THE FULL SONG
2. When interacting while the song is playing (like clicking a radio button or checkbox) the song will stop and the player will reset to the beginning of the song at max volume
3. Adding autoplay is easy but I left it out because of point 2